### PR TITLE
fix dynamic method to match php 7 syntax - adds support for php 7

### DIFF
--- a/src/controllers/StationPanelController.php
+++ b/src/controllers/StationPanelController.php
@@ -727,7 +727,7 @@ class StationPanelController extends \BaseController {
 				$override['method'] = substr($override['method'],0,strpos($override['method'], '('));
 			}
 			else $vars = '';
-			return App::make($override['controller'])->$override['method']($vars);
+			return App::make($override['controller'])->{$override['method']}($vars);
 
 		}
 

--- a/src/views/layouts/form.blade.php
+++ b/src/views/layouts/form.blade.php
@@ -162,7 +162,7 @@
 								<span class="input-group-addon"><span class="{{ $with_prepend_icon }}"></span></span>
 							@endif
 
-							{{ Form::$element_info['type']($element_name, $default_value, $attributes) }}
+							{{ Form::{$element_info['type']}($element_name, $default_value, $attributes) }}
 
 							@if ($with_append)
 								<span class="input-group-addon">{{ $element_info['append'] }}</span>


### PR DESCRIPTION
for method following the pattern `$object->$array['method']($vars)` we need to change it to `$object->{$array['method']}($vars)` so php understands the first is the method and the second variable the arguments.  http://php.net/manual/en/functions.variable-functions.php